### PR TITLE
fix "Cannot find module" error for ant-design-pro's .eslintrc.js

### DIFF
--- a/src/eslintJs.ts
+++ b/src/eslintJs.ts
@@ -5,6 +5,7 @@ import { FileEntity } from './typing';
 const importCache = require('import-fresh');
 
 const engine = new CLIEngine({
+  useEslintrc: false,
   fix: true,
   baseConfig: importCache(path.resolve(__dirname, '../eslintrc.js')),
 });


### PR DESCRIPTION
fix "Cannot find module" error when ant-design-pro has require some other module in .eslintrc.js

if create-umi’s sylvanas in package.json update to the latest version of sylvanas, then run and choose "ant-design-pro" with "JavaScript" language , it will emit error of "Cannot find module @umijs/fabric".

修复当ant-design-pro的.eslintrc.js文件中有引入其它的包时报"Cannot find module"错误的bug。

如果将create-umi的package.json中的sylvanas更新到最新版本，然后运行并选择JavaScript版本的ant-design-pro，会报"Cannot find module @umijs/fabric"的错误。