### PR TITLE
fix: eslint 报 plugin-missing MODULE_NOT_FOUND 错误

### DIFF
--- a/src/eslintJs.ts
+++ b/src/eslintJs.ts
@@ -8,6 +8,7 @@ const engine = new CLIEngine({
   useEslintrc: false,
   fix: true,
   baseConfig: importCache(path.resolve(__dirname, '../.eslintrc.js')),
+  resolvePluginsRelativeTo: path.resolve(__dirname, '..'),
 });
 
 export const lintAndFix: (content: string, filename?: string) => string = (content, filename) => {


### PR DESCRIPTION
yarn create umi

选择 JavaScript 后，eslint 会报 plugin-missing MODULE_NOT_FOUND 错误